### PR TITLE
fix: various build blockers

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -937,7 +937,7 @@ void move_items_activity_actor::do_turn( player_activity &act, Character &who )
         // Handle charges, quantity == 0 means move all
         /*if( quantity != 0 && target->count_by_charges() ) {
             // If it's only a partial stack move, make a copy to be put in the destination location
-            newit = item_spawn( *target );
+            newit = item::spawn( *target );
             newit->charges = std::min( newit->charges, quantity );
             target->charges -= quantity;
         } else {

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1104,7 +1104,7 @@ static void butchery_drops_harvest( item *corpse_item, const mtype &mt, player &
                     obj.set_var( "activity_var", p.name );
                 }
                 for( int i = 0; i != roll; ++i ) {
-                    here.add_item_or_charges( p.pos(), std::move( item::spawn( obj ) ) );
+                    here.add_item_or_charges( p.pos(), item::spawn( obj ) );
                 }
             }
             p.add_msg_if_player( m_good, _( "You harvest: %s" ), drop->nname( roll ) );
@@ -1127,7 +1127,7 @@ static void butchery_quarter( item *corpse_item, const player &p )
     map &here = get_map();
     // 4 quarters (one exists, add 3, flag does the rest)
     for( int i = 1; i <= 3; i++ ) {
-        here.add_item_or_charges( p.pos(), std::move( item::spawn( *corpse_item ) ), true );
+        here.add_item_or_charges( p.pos(), item::spawn( *corpse_item ) , true );
     }
 }
 
@@ -3050,7 +3050,7 @@ void activity_handlers::toolmod_add_finish( player_activity *act, player *p )
     p->add_msg_if_player( m_good, _( "You successfully attached the %1$s to your %2$s." ),
                           mod.tname(), tool.tname() );
     mod.set_flag( "IRREMOVABLE" );
-    tool.put_in( std::move( mod.detach() ) );
+    tool.put_in( mod.detach() );
 }
 
 void activity_handlers::clear_rubble_finish( player_activity *act, player *p )
@@ -3175,9 +3175,9 @@ static void rod_fish( player *p, const std::vector<monster *> &fishables )
         const std::vector<mtype_id> fish_group = MonsterGroupManager::GetMonstersFromGroup(
                     mongroup_id( "GROUP_FISH" ) );
         const mtype_id fish_mon = random_entry_ref( fish_group );
-        here.add_item_or_charges( p->pos(), std::move( item::make_corpse( fish_mon,
+        here.add_item_or_charges( p->pos(), item::make_corpse( fish_mon,
                                   calendar::turn + rng( 0_turns,
-                                          3_hours ) ) ) );
+                                          3_hours ) ) );
         p->add_msg_if_player( m_good, _( "You caught a %s." ), fish_mon.obj().nname() );
     } else {
         monster *chosen_fish = random_entry( fishables );
@@ -3185,9 +3185,9 @@ static void rod_fish( player *p, const std::vector<monster *> &fishables )
         if( chosen_fish->fish_population <= 0 ) {
             g->catch_a_monster( chosen_fish, p->pos(), p, 50_hours );
         } else {
-            here.add_item_or_charges( p->pos(), std::move( item::make_corpse( chosen_fish->type->id,
+            here.add_item_or_charges( p->pos(), item::make_corpse( chosen_fish->type->id,
                                       calendar::turn + rng( 0_turns,
-                                              3_hours ) ) ) );
+                                              3_hours ) ) );
             p->add_msg_if_player( m_good, _( "You caught a %s." ), chosen_fish->type->nname() );
         }
     }
@@ -4795,5 +4795,5 @@ void activity_handlers::mind_splicer_finish( player_activity *act, player *p )
     p->add_msg_if_player( m_info, _( "…you finally find the memory banks." ) );
     p->add_msg_if_player( m_info, _( "The kit makes a copy of the data inside the bionic." ) );
     data_card.contents.clear_items();
-    data_card.put_in( std::move( item::spawn( itype_mind_scan_robofac ) ) );
+    data_card.put_in( item::spawn( itype_mind_scan_robofac ) );
 }

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1127,7 +1127,7 @@ static void butchery_quarter( item *corpse_item, const player &p )
     map &here = get_map();
     // 4 quarters (one exists, add 3, flag does the rest)
     for( int i = 1; i <= 3; i++ ) {
-        here.add_item_or_charges( p.pos(), item::spawn( *corpse_item ) , true );
+        here.add_item_or_charges( p.pos(), item::spawn( *corpse_item ), true );
     }
 }
 

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1954,7 +1954,7 @@ static bool tidy_activity( player &p, const tripoint &src_loc,
         for( item *inv_elem : p.inv_dump() ) {
             if( inv_elem->has_var( "activity_var" ) ) {
                 inv_elem->erase_var( "activity_var" );
-                put_into_vehicle_or_drop( p, item_drop_reason::deliberate, p.i_rem( inv_elem ) ,
+                put_into_vehicle_or_drop( p, item_drop_reason::deliberate, p.i_rem( inv_elem ),
                                           src_loc );
             }
         }

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -635,9 +635,9 @@ std::vector<detached_ptr<item>> obtain_and_tokenize_items( player &p, std::list<
                 continue;
             }
         } else if( ait.loc->count_by_charges() ) {
-            res.push_back( std::move( p.reduce_charges( const_cast<item *>( &*ait.loc ), ait.count ) ) );
+            res.push_back( p.reduce_charges( const_cast<item *>( &*ait.loc ), ait.count ) );
         } else {
-            res.push_back( std::move( p.i_rem( &*ait.loc ) ) );
+            res.push_back( p.i_rem( &*ait.loc ) );
         }
 
         // TODO: Get the item consistently instead of using back()
@@ -708,7 +708,7 @@ void drop_activity_actor::do_turn( player_activity &, Character &who )
 {
     const tripoint pos = who.pos() + relpos;
 
-    std::vector<detached_ptr<item>> dropped = std::move( obtain_activity_items( who, items ) );
+    std::vector<detached_ptr<item>> dropped = obtain_activity_items( who, items ) ;
 
     put_into_vehicle_or_drop( who, item_drop_reason::deliberate,
                               dropped, pos, force_ground );
@@ -982,7 +982,7 @@ static void move_item( player &p, item &it, const int quantity, const tripoint &
     if( it.made_of( LIQUID ) ) {
         return;
     }
-    detached_ptr<item> moved = std::move( it.split( quantity ) );
+    detached_ptr<item> moved = it.split( quantity ) ;
 
     p.mod_moves( -move_cost( it, src, dest ) );
     if( activity_to_restore == ACT_TIDY_UP ) {
@@ -1954,7 +1954,7 @@ static bool tidy_activity( player &p, const tripoint &src_loc,
         for( item *inv_elem : p.inv_dump() ) {
             if( inv_elem->has_var( "activity_var" ) ) {
                 inv_elem->erase_var( "activity_var" );
-                put_into_vehicle_or_drop( p, item_drop_reason::deliberate, std::move( p.i_rem( inv_elem ) ),
+                put_into_vehicle_or_drop( p, item_drop_reason::deliberate, p.i_rem( inv_elem ) ,
                                           src_loc );
             }
         }
@@ -2018,7 +2018,7 @@ static bool fetch_activity( player &p, const tripoint &src_loc,
                         continue;
                     }
                     //This invalidates our iterator but we don't care because it isn't used again
-                    detached_ptr<item> moved = std::move( it.split( pickup_count ) );
+                    detached_ptr<item> moved = it.split( pickup_count ) ;
                     moved->set_var( "activity_var", p.name );
                     const std::string item_name = moved->tname();
                     if( p.is_npc() ) {

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -1676,7 +1676,7 @@ bool advanced_inventory::move_content( item &src_container, item &dest_container
         }
         src_container.on_contents_changed();
     }
-    detached_ptr<item> moved = std::move( src_contents.split( amount ) );
+    detached_ptr<item> moved = src_contents.split( amount ) ;
     dest_container.fill_with( std::move( moved ), amount );
 
     uistate.adv_inv_container_content_type = dest_container.contents.front().typeId();

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -722,21 +722,21 @@ void avatar_action::fire_wielded_weapon( avatar &you )
         return;
     }
 
-    you.assign_activity( std::move( std::make_unique<player_activity>
-                                    ( aim_activity_actor::use_wielded() ) ), false );
+    you.assign_activity( std::make_unique<player_activity>
+                                    ( aim_activity_actor::use_wielded() ) , false );
 }
 
 void avatar_action::fire_ranged_mutation( avatar &you, detached_ptr<item> &&fake_gun )
 {
-    you.assign_activity( std::move( std::make_unique<player_activity>( aim_activity_actor::use_mutation(
-                                        std::move( fake_gun ) ) ) ), false );
+    you.assign_activity( std::make_unique<player_activity>( aim_activity_actor::use_mutation(
+                                        std::move( fake_gun ) ) ) , false );
 }
 
 void avatar_action::fire_ranged_bionic( avatar &you, detached_ptr<item> &&fake_gun,
                                         const units::energy &cost_per_shot )
 {
-    you.assign_activity( std::move( std::make_unique<player_activity>( aim_activity_actor::use_bionic(
-                                        std::move( fake_gun ), cost_per_shot ) ) ),
+    you.assign_activity( std::make_unique<player_activity>( aim_activity_actor::use_bionic(
+                                        std::move( fake_gun ), cost_per_shot ) ) ,
                          false );
 }
 
@@ -1075,13 +1075,13 @@ void avatar_action::wield( item &loc )
                 if( worn_index != INT_MIN ) {
                     auto it = u.worn.begin();
                     std::advance( it, worn_index );
-                    u.worn.insert( it, std::move( to_wield->detach() ) );
+                    u.worn.insert( it, to_wield->detach() );
                 } else {
-                    u.i_add( std::move( to_wield->detach() ) );
+                    u.i_add( to_wield->detach() );
                 }
                 break;
             case item_location_type::map:
-                here.add_item( pos, std::move( to_wield->detach() ) );
+                here.add_item( pos, to_wield->detach() );
                 break;
             case item_location_type::vehicle: {
                 const cata::optional<vpart_reference> vp = here.veh_at( pos ).part_with_feature( "CARGO", false );
@@ -1210,7 +1210,7 @@ void avatar_action::reload( item &loc, bool prompt, bool empty )
         } else {
             u.activity->targets.emplace_back( opt.target );
         }
-        u.activity->targets.push_back( std::move( opt.ammo ) );
+        u.activity->targets.push_back( opt.ammo );
     }
 }
 
@@ -1295,7 +1295,7 @@ void avatar_action::reload_weapon( bool try_everything )
             u.assign_activity( std::make_unique<player_activity>( activity_id( "ACT_RELOAD" ), opt.moves(),
                                opt.qty() ) );
             u.activity->targets.emplace_back( turret.base() );
-            u.activity->targets.push_back( std::move( opt.ammo ) );
+            u.activity->targets.push_back( opt.ammo );
         }
         return;
     }

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -723,20 +723,20 @@ void avatar_action::fire_wielded_weapon( avatar &you )
     }
 
     you.assign_activity( std::make_unique<player_activity>
-                                    ( aim_activity_actor::use_wielded() ) , false );
+                         ( aim_activity_actor::use_wielded() ), false );
 }
 
 void avatar_action::fire_ranged_mutation( avatar &you, detached_ptr<item> &&fake_gun )
 {
     you.assign_activity( std::make_unique<player_activity>( aim_activity_actor::use_mutation(
-                                        std::move( fake_gun ) ) ) , false );
+                             std::move( fake_gun ) ) ), false );
 }
 
 void avatar_action::fire_ranged_bionic( avatar &you, detached_ptr<item> &&fake_gun,
                                         const units::energy &cost_per_shot )
 {
     you.assign_activity( std::make_unique<player_activity>( aim_activity_actor::use_bionic(
-                                        std::move( fake_gun ), cost_per_shot ) ) ,
+                             std::move( fake_gun ), cost_per_shot ) ),
                          false );
 }
 

--- a/src/avatar_functions.cpp
+++ b/src/avatar_functions.cpp
@@ -463,7 +463,7 @@ bool gunmod_remove( avatar &you, item &gun, item &mod )
 
     const itype *modtype = mod.type;
 
-    you.i_add_or_drop( std::move( gun.remove_item( mod ) ) );
+    you.i_add_or_drop( gun.remove_item( mod ) );
 
     //If the removed gunmod added mod locations, check to see if any mods are in invalid locations
     if( !modtype->gunmod->add_mod.empty() ) {
@@ -588,7 +588,7 @@ void use_item( avatar &you, item &used )
     } else if( used.has_flag( flag_SPLINT ) ) {
         ret_val<bool> need_splint = you.can_wear( used );
         if( need_splint.success() ) {
-            you.wear_item( std::move( used.detach() ) );
+            you.wear_item( used.detach() );
         } else {
             add_msg( m_info, need_splint.str() );
         }

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -456,7 +456,7 @@ void npc::discharge_cbm_weapon()
     }
     const bionic &bio = ( *my_bionics )[cbm_weapon_index];
     mod_power_level( -bio.info().power_activate );
-    set_weapon( std::move( remove_real_weapon() ) );
+    set_weapon( remove_real_weapon() );
     cbm_weapon_index = -1;
 }
 
@@ -504,7 +504,7 @@ void npc::check_or_use_weapon_cbm( const bionic_id &cbm_id )
 
         if( npc_ai::weapon_value( *this, get_weapon(), ammo_count ) < npc_ai::weapon_value( *this,
                 *cbm_weapon, cbm_ammo ) ) {
-            set_real_weapon( std::move( remove_weapon() ) );
+            set_real_weapon( remove_weapon() );
             set_weapon( std::move( cbm_weapon ) );
             cbm_weapon_index = index;
         }
@@ -517,7 +517,7 @@ void npc::check_or_use_weapon_cbm( const bionic_id &cbm_id )
             add_msg( m_info, _( "%s activates their %s." ), disp_name(), bio.info().name );
         }
 
-        set_weapon( std::move( item::spawn( bio.info().fake_item ) ) );
+        set_weapon( item::spawn( bio.info().fake_item ) );
         mod_power_level( -bio.info().power_activate );
         bio.powered = true;
         cbm_weapon_index = index;
@@ -591,7 +591,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only )
         refund_power(); // Power usage calculated later, in avatar_action::fire
         //TODO!: check lifetime
         avatar_action::fire_ranged_bionic( *this->as_avatar(),
-                                           std::move( item::spawn( bio.info().fake_item ) ),
+                                           item::spawn( bio.info().fake_item ) ,
                                            bio.info().power_activate );
     } else if( bio.info().has_flag( flag_BIONIC_WEAPON ) ) {
         if( weapon->has_flag( flag_NO_UNWIELD ) ) {
@@ -611,7 +611,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only )
         }
 
         add_msg_activate();
-        set_weapon( std::move( item::spawn( bio.info().fake_item ) ) );
+        set_weapon( item::spawn( bio.info().fake_item ) );
         get_weapon().invlet = '#';
         if( bio.ammo_count > 0 ) {
             weapon->ammo_set( bio.ammo_loaded, bio.ammo_count );

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -591,7 +591,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only )
         refund_power(); // Power usage calculated later, in avatar_action::fire
         //TODO!: check lifetime
         avatar_action::fire_ranged_bionic( *this->as_avatar(),
-                                           item::spawn( bio.info().fake_item ) ,
+                                           item::spawn( bio.info().fake_item ),
                                            bio.info().power_activate );
     } else if( bio.info().has_flag( flag_BIONIC_WEAPON ) ) {
         if( weapon->has_flag( flag_NO_UNWIELD ) ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2468,7 +2468,7 @@ detached_ptr<item> Character::i_rem( int pos )
         tmp->on_takeoff( *this );
         detached_ptr<item> ret;
         worn.erase( iter, &ret );
-        return std::move( ret );
+        return ret ;
     }
     return inv.remove_item( pos );
 }
@@ -2487,14 +2487,14 @@ detached_ptr<item> Character::i_rem( const item *it )
         debugmsg( "did not found item %s to remove it!", it->tname() );
         return detached_ptr<item>();
     }
-    return std::move( ret );
+    return ret ;
 }
 
 detached_ptr<item> Character::i_rem_keep_contents( const int idx )
 {
     detached_ptr<item> ret = i_rem( idx );
     ret->spill_contents( pos() );
-    return std::move( ret );
+    return ret ;
 }
 
 detached_ptr<item> Character::i_add_or_drop( detached_ptr<item> &&it )
@@ -10666,7 +10666,7 @@ void Character::start_destination_activity()
         return;
     }
 
-    assign_activity( std::move( clear_destination() ) );
+    assign_activity( clear_destination() );
 }
 
 std::vector<tripoint> &Character::get_auto_move_route()

--- a/src/computer_session.cpp
+++ b/src/computer_session.cpp
@@ -378,7 +378,7 @@ void computer_session::action_sample()
                 }
                 capa = std::min( sewage->charges, capa );
                 if( elem->contents.empty() ) {
-                    elem->put_in( std::move( item::spawn( itype_sewage, calendar::turn ) ) );
+                    elem->put_in( item::spawn( itype_sewage, calendar::turn ) );
                     elem->contents.front().charges = capa;
                 } else {
                     elem->contents.front().charges += capa;

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -2217,7 +2217,7 @@ void crafting::complete_disassemble( Character &who, iuse_location target,
             }
 
             for( ; compcount > 0; compcount-- ) {
-                components.push_back( std::move( item::spawn( *newit ) ) );
+                components.push_back( item::spawn( *newit ) );
             }
         }
     }

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -2431,7 +2431,7 @@ void basecamp::start_farm_op( point dir, const tripoint_abs_omt &omt_tgt, farm_o
             }
             work += 1_minutes * plots_seeded;
             start_mission( "_faction_exp_plant_" + dir_id, work, true,
-                           _( "begins planting the field…" ), false, std::move( plant_these ),
+                           _( "begins planting the field…" ), false, plant_these ,
                            skill_survival, 1 );
             break;
         }

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -2431,7 +2431,7 @@ void basecamp::start_farm_op( point dir, const tripoint_abs_omt &omt_tgt, farm_o
             }
             work += 1_minutes * plots_seeded;
             start_mission( "_faction_exp_plant_" + dir_id, work, true,
-                           _( "begins planting the field…" ), false, plant_these ,
+                           _( "begins planting the field…" ), false, plant_these,
                            skill_survival, 1 );
             break;
         }

--- a/src/item.h
+++ b/src/item.h
@@ -276,7 +276,7 @@ class item : public location_visitable<item>, public game_object<item>
         inline static detached_ptr<item> spawn( JsonIn &jsin ) {
             detached_ptr<item> p = spawn();
             p->deserialize( jsin );
-            return std::move( p );
+            return p ;
         }
 
         inline static detached_ptr<item>spawn( const item &source ) {
@@ -288,7 +288,7 @@ class item : public location_visitable<item>, public game_object<item>
 
         template<typename... T>
         inline static detached_ptr<item>spawn( T... args ) {
-            return std::move( detached_ptr<item>( new item( std::forward<T>( args )... ) ) );
+            return detached_ptr<item>( new item( std::forward<T>( args )... ) ) ;
         }
 
         inline static item *spawn_temporary( const item &source ) {

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -3006,7 +3006,7 @@ int ammobelt_actor::use( player &p, item &, bool, const tripoint & ) const
     if( opt ) {
         p.assign_activity( ACT_RELOAD, opt.moves(), opt.qty() );
         p.activity->targets.emplace_back( &*mag );
-        p.activity->targets.push_back( std::move( opt.ammo ) );
+        p.activity->targets.push_back( opt.ammo );
         p.i_add( std::move( mag ) );
     }
 

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -1199,7 +1199,7 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
     g->u.assign_activity( player_activity( pickup_activity_actor( targets, g->u.pos() ) ) );
     if( min == -1 ) {
         // Auto pickup will need to auto resume since there can be several of them on the stack.
-        g->u.activity.auto_resume = true;
+        g->u.activity->auto_resume = true;
     }
 
     g->reenter_fullscreen();

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -169,7 +169,7 @@ item *player::reduce_charges( int position, int quantity )
         return &i_rem( position );
     }
     it.mod_charges( -quantity );
-    item *tmp = item_spawn( it );
+    item *tmp = item::spawn( it );
     tmp->charges = quantity;
     return tmp;
 }
@@ -184,7 +184,7 @@ item *player::reduce_charges( item *it, int quantity )
         return &i_rem( it );
     }
     it->mod_charges( -quantity );
-    item *result = item_spawn( *it );
+    item *result = item::spawn( *it );
     result->charges = quantity;
     return result;
 }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -122,7 +122,7 @@ player::player()
     cash = 0;
     scent = 500;
     male = true;
-    set_weapon( null_item_reference() );
+    remove_weapon();
 
     start_location = start_location_id( "sloc_shelter" );
     moves = 100;
@@ -158,35 +158,37 @@ player::~player() = default;
 player::player( player && ) = default;
 player &player::operator=( player && ) = default;
 
-item *player::reduce_charges( int position, int quantity )
+detached_ptr<item> player::reduce_charges( int position, int quantity )
 {
     item &it = i_at( position );
     if( it.is_null() ) {
         debugmsg( "invalid item position %d for reduce_charges", position );
-        return &null_item_reference();
+        return detached_ptr<item>();
     }
     if( it.charges <= quantity ) {
-        return &i_rem( position );
+        return i_rem( position );
     }
     it.mod_charges( -quantity );
-    item *tmp = item::spawn( it );
-    tmp->charges = quantity;
-    return tmp;
+
+    auto taken = item::spawn( it );
+    taken->charges = quantity;
+    return taken;
 }
 
-item *player::reduce_charges( item *it, int quantity )
+detached_ptr<item> player::reduce_charges( item *it, int quantity )
 {
     if( !has_item( *it ) ) {
         debugmsg( "invalid item (name %s) for reduce_charges", it->tname() );
-        return &null_item_reference();
+        return detached_ptr<item>();
     }
     if( it->charges <= quantity ) {
-        return &i_rem( it );
+        return i_rem( it );
     }
     it->mod_charges( -quantity );
-    item *result = item::spawn( *it );
-    result->charges = quantity;
-    return result;
+
+    auto taken = item::spawn( *it );
+    taken->charges = quantity;
+    return taken;
 }
 
 // ids of martial art styles that are available with the bio_cqb bionic.

--- a/src/player.h
+++ b/src/player.h
@@ -125,6 +125,8 @@ class player : public Character
          * Otherwise identical to @ref reduce_charges(int,int)
          * @param it A pointer to the item, it *must* exist.
          * @param quantity How many charges to remove
+         * @return An item that contains the removed charges, it's effectively a
+         * copy of the item with the proper charges.
          */
         detached_ptr<item> reduce_charges( item *it, int quantity );
 

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -245,7 +245,7 @@ cata::optional<std::string> player_activity::get_progress_message( const avatar 
         }
 
         if( type == activity_id( "ACT_BUILD" ) ) {
-            partial_con *pc = get_map().partial_con_at( get_map().getlocal( u.activity.placement ) );
+            partial_con *pc = get_map().partial_con_at( get_map().getlocal( u.activity->placement ) );
             if( pc ) {
                 int counter = std::min( pc->counter, 10000000 );
                 const int percentage = counter / 100000;

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -211,7 +211,7 @@ static void eff_fun_bleed( player &u, effect &it )
     // on the wound or otherwise suppressing the flow. (Kits contain either
     // QuikClot or bandages per the recipe.)
     const int intense = it.get_intensity();
-    if( one_in( 36 / intense ) && u.activity.id() != ACT_FIRSTAID ) {
+    if( one_in( 36 / intense ) && u.activity->id() != ACT_FIRSTAID ) {
         u.add_msg_player_or_npc( m_bad, _( "You lose some blood." ),
                                  _( "<npcname> loses some blood." ) );
         // Prolonged hemorrhage is a significant risk for developing anemia
@@ -1256,7 +1256,7 @@ void Character::hardcoded_effects( effect &it )
                 if( dur == 1_turns ) {
                     if( !asleep ) {
                         add_msg_if_player( _( "Your internal chronometer went off and you haven't slept a wink." ) );
-                        activity.set_to_null();
+                        activity->set_to_null();
                     } else {
                         // Secure the flag before wake_up() clears the effect
                         bool slept_through = has_effect( effect_slept_through_alarm );

--- a/src/profession.cpp
+++ b/src/profession.cpp
@@ -388,7 +388,7 @@ ItemList profession::items( bool male, const std::vector<trait_id> &traits ) con
     ItemList result;
     auto add_legacy_items = [&result]( const itypedecvec & vec ) {
         for( const itypedec &elem : vec ) {
-            item *it = item_spawn( elem.type_id, advanced_spawn_time(), item::default_charges_tag {} );
+            item *it = item::spawn( elem.type_id, advanced_spawn_time(), item::default_charges_tag {} );
             if( !elem.snip_id.is_null() ) {
                 it->set_snippet( elem.snip_id );
             }
@@ -410,7 +410,7 @@ ItemList profession::items( bool male, const std::vector<trait_id> &traits ) con
     std::vector<itype_id> bonus = item_substitutions.get_bonus_items( traits );
     for( const itype_id &elem : bonus ) {
         if( elem != no_bonus ) {
-            result.push_back( item_spawn( elem, advanced_spawn_time(), item::default_charges_tag {} ) );
+            result.push_back( item::spawn( elem, advanced_spawn_time(), item::default_charges_tag {} ) );
         }
     }
     for( auto iter = result.begin(); iter != result.end(); ) {
@@ -669,13 +669,13 @@ std::vector<item *> json_item_substitution::get_substitution( const item &it,
 
     const int old_amt = it.count();
     for( const substitution::info &inf : sub->infos ) {
-        item *result = item_spawn( inf.new_item, advanced_spawn_time() );
+        item *result = item::spawn( inf.new_item, advanced_spawn_time() );
         const int new_amt = std::max( 1, static_cast<int>( std::round( inf.ratio * old_amt ) ) );
         if( !result->count_by_charges() ) {
             for( int i = 0; i < new_amt; i++ ) {
                 ret.push_back( &result->in_its_container() );
                 if( i < new_amt ) {
-                    result = item_spawn( inf.new_item, advanced_spawn_time() );
+                    result = item::spawn( inf.new_item, advanced_spawn_time() );
                 }
             }
         } else {
@@ -683,7 +683,7 @@ std::vector<item *> json_item_substitution::get_substitution( const item &it,
             while( result->charges > 0 ) {
                 item *pushed = &result->in_its_container();
                 ret.push_back( pushed );
-                result = item_spawn( *result );
+                result = item::spawn( *result );
                 result->mod_charges( pushed->contents.empty() ? -pushed->charges :
                                      -pushed->contents.back().charges );
             }

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1695,13 +1695,13 @@ static projectile make_gun_projectile( const item &gun )
         bool recover = !one_in( ammo.dont_recover_one_in );
 
         if( recover && !fx.has_effect( ammo_effect_IGNITE ) && !fx.has_effect( ammo_effect_EXPLOSIVE ) ) {
-            item &drop = *item_spawn( gun.ammo_current(), calendar::turn, 1 );
+            item &drop = *item::spawn( gun.ammo_current(), calendar::turn, 1 );
             drop.active = fx.has_effect( ammo_effect_ACT_ON_RANGED_HIT );
             proj.set_drop( drop );
         }
 
         if( ammo.drop ) {
-            item &drop = *item_spawn( ammo.drop );
+            item &drop = *item::spawn( ammo.drop );
             if( ammo.drop_active ) {
                 drop.activate();
             }
@@ -1745,12 +1745,12 @@ static void cycle_action( item &weap, const tripoint &pos )
     if( weap.ammo_data() && weap.ammo_data()->ammo->casing ) {
         const itype_id casing = *weap.ammo_data()->ammo->casing;
         if( weap.has_flag( "RELOAD_EJECT" ) || weap.gunmod_find( itype_brass_catcher ) ) {
-            weap.put_in( item_spawn( casing )->set_flag( "CASING" ) );
+            weap.put_in( item::spawn( casing )->set_flag( "CASING" ) );
         } else {
             if( cargo.empty() ) {
-                here.add_item_or_charges( eject, *item_spawn( casing ) );
+                here.add_item_or_charges( eject, *item::spawn( casing ) );
             } else {
-                vp->vehicle().add_item( *cargo.front(), *item_spawn( casing ) );
+                vp->vehicle().add_item( *cargo.front(), *item::spawn( casing ) );
             }
 
             sfx::play_variant_sound( "fire_gun", "brass_eject", sfx::get_heard_volume( eject ),
@@ -1761,7 +1761,7 @@ static void cycle_action( item &weap, const tripoint &pos )
     // some magazines also eject disintegrating linkages
     const auto mag = weap.magazine_current();
     if( mag && mag->type->magazine->linkage ) {
-        item &linkage = *item_spawn( *mag->type->magazine->linkage, calendar::turn, 1 );
+        item &linkage = *item::spawn( *mag->type->magazine->linkage, calendar::turn, 1 );
         if( weap.gunmod_find( itype_brass_catcher ) ) {
             linkage.set_flag( "CASING" );
             weap.put_in( linkage );

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -823,7 +823,7 @@ bool recipe::hot_result() const
     // does get heated we'll find it right away.
     //
     // TODO: Make this less of a hack
-    if( create_result().is_food() ) {
+    if( create_result()->is_food() ) {
         const requirement_data::alter_tool_comp_vector &tool_lists = simple_requirements().get_tools();
         for( const std::vector<tool_comp> &tools : tool_lists ) {
             for( const tool_comp &t : tools ) {

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -456,7 +456,7 @@ std::string recipe::get_consistency_error() const
 item &recipe::create_result() const
 {
     //TODO!: check
-    item *newit = item_spawn( result_, calendar::turn, item::default_charges_tag{} );
+    item *newit = item::spawn( result_, calendar::turn, item::default_charges_tag{} );
     if( charges ) {
         newit->charges = *charges;
     }
@@ -506,7 +506,7 @@ std::vector<item *> recipe::create_byproducts( int batch ) const
 {
     std::vector<item *> bps;
     for( const auto &e : byproducts ) {
-        item &obj = *item_spawn( e.first, calendar::turn, item::default_charges_tag{} );
+        item &obj = *item::spawn( e.first, calendar::turn, item::default_charges_tag{} );
         if( obj.has_flag( "VARSIZE" ) ) {
             obj.set_flag( "FIT" );
         }
@@ -521,7 +521,7 @@ std::vector<item *> recipe::create_byproducts( int batch ) const
             }
             for( int i = 0; i < e.second * batch; ++i ) {
                 //TODO!:check
-                bps.push_back( i == 0 ? &obj : item_spawn( obj ) );
+                bps.push_back( i == 0 ? &obj : item::spawn( obj ) );
             }
         }
     }

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -464,12 +464,12 @@ void Character::load( const JsonObject &data )
     data.read( "stashed_outbounds_activity", stashed_outbounds_activity );
     data.read( "stashed_outbounds_backlog", stashed_outbounds_backlog );
     data.read( "backlog", backlog );
-    if( !backlog.empty() && !backlog.front().str_values.empty() && ( ( activity &&
-            activity.id() == activity_id( "ACT_FETCH_REQUIRED" ) ) || ( destination_activity &&
-                    destination_activity.id() == activity_id( "ACT_FETCH_REQUIRED" ) ) ) ) {
+    if( !backlog.empty() && !backlog.front()->str_values.empty() && ( ( activity &&
+            activity->id() == activity_id( "ACT_FETCH_REQUIRED" ) ) || ( destination_activity &&
+                    destination_activity->id() == activity_id( "ACT_FETCH_REQUIRED" ) ) ) ) {
         requirement_data fetch_reqs;
         data.read( "fetch_data", fetch_reqs );
-        const requirement_id req_id( backlog.front().str_values.back() );
+        const requirement_id req_id( backlog.front()->str_values.back() );
         requirement_data::save_requirement( fetch_reqs, req_id );
     }
     // npc activity on vehicles.
@@ -716,10 +716,10 @@ void Character::store( JsonOut &json ) const
     json.member( "activity_vehicle_part_index", activity_vehicle_part_index ); // NPC activity
 
     // handling for storing activity requirements
-    if( !backlog.empty() && !backlog.front().str_values.empty() && ( ( activity &&
-            activity.id() == activity_id( "ACT_FETCH_REQUIRED" ) ) || ( destination_activity &&
-                    destination_activity.id() == activity_id( "ACT_FETCH_REQUIRED" ) ) ) ) {
-        requirement_data things_to_fetch = requirement_id( backlog.front().str_values.back() ).obj();
+    if( !backlog.empty() && !backlog.front()->str_values.empty() && ( ( activity &&
+            activity->id() == activity_id( "ACT_FETCH_REQUIRED" ) ) || ( destination_activity &&
+                    destination_activity->id() == activity_id( "ACT_FETCH_REQUIRED" ) ) ) ) {
+        requirement_data things_to_fetch = requirement_id( backlog.front()->str_values.back() ).obj();
         json.member( "fetch_data", things_to_fetch );
     }
 
@@ -1489,7 +1489,7 @@ void npc::load( const JsonObject &data )
     if( data.read( "current_activity_id", act_id ) ) {
         current_activity_id = activity_id( act_id );
     } else if( activity ) {
-        current_activity_id = activity.id();
+        current_activity_id = activity->id();
     }
 
     if( data.has_member( "pulp_locationx" ) ) {
@@ -3939,9 +3939,9 @@ void submap::store( JsonOut &jsout ) const
         jsout.write( elem.first.y );
         jsout.write( elem.first.z );
         jsout.write( elem.second.counter );
-        jsout.write( elem.second.id.id() );
+        jsout.write( elem.second->id.id() );
         jsout.start_array();
-        for( auto &it : elem.second.components ) {
+        for( auto &it : elem.second->components ) {
             jsout.write( it );
         }
         jsout.end_array();

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -1764,7 +1764,7 @@ void inventory::json_load_items( JsonIn &jsin )
 {
     jsin.start_array();
     while( !jsin.end_array() ) {
-        add_item( *item_spawn( jsin ), true, false );
+        add_item( *item::spawn( jsin ), true, false );
     }
 }
 
@@ -1802,23 +1802,23 @@ void monster::load( const JsonObject &data )
     }
     if( data.has_object( "tied_item" ) ) {
         JsonIn *tied_item_json = data.get_raw( "tied_item" );
-        set_tied_item( item_spawn( *tied_item_json ) );
+        set_tied_item( item::spawn( *tied_item_json ) );
     }
     if( data.has_object( "tack_item" ) ) {
         JsonIn *tack_item_json = data.get_raw( "tack_item" );
-        set_tack_item( item_spawn( *tack_item_json ) );
+        set_tack_item( item::spawn( *tack_item_json ) );
     }
     if( data.has_object( "armor_item" ) ) {
         JsonIn *armor_item_json = data.get_raw( "armor_item" );
-        set_armor_item( item_spawn( *armor_item_json ) );
+        set_armor_item( item::spawn( *armor_item_json ) );
     }
     if( data.has_object( "storage_item" ) ) {
         JsonIn *storage_item_json = data.get_raw( "storage_item" );
-        set_storage_item( item_spawn( *storage_item_json ) );
+        set_storage_item( item::spawn( *storage_item_json ) );
     }
     if( data.has_object( "battery_item" ) ) {
         JsonIn *battery_item_json = data.get_raw( "battery_item" );
-        set_battery_item( item_spawn( *battery_item_json ) );
+        set_battery_item( item::spawn( *battery_item_json ) );
     }
     data.read( "hp", hp );
 
@@ -2470,7 +2470,7 @@ void vehicle_part::deserialize( JsonIn &jsin )
         data.read( "base", base );
     } else {
         // handle legacy format which didn't include the base item
-        base = item_spawn( id.obj().item );
+        base = item::spawn( id.obj().item );
     }
 
     data.read( "mount_dx", mount.x );

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -475,7 +475,7 @@ void sounds::process_sound_markers( player *p )
 
         // don't print our own noise or things without descriptions
         if( !sound.ambient && ( pos != p->pos() ) && !get_map().pl_sees( pos, distance_to_sound ) ) {
-            if( !p->activity.is_distraction_ignored( distraction_type::noise ) &&
+            if( !p->activity->is_distraction_ignored( distraction_type::noise ) &&
                 !get_safemode().is_sound_safe( sound.description, distance_to_sound ) ) {
                 const std::string query = string_format( _( "Heard %s!" ), description );
                 g->cancel_activity_or_ignore_query( distraction_type::noise, query );
@@ -512,7 +512,7 @@ void sounds::process_sound_markers( player *p )
                     add_msg( _( "Your alarm clock wakes you up." ) );
                 } else {
                     add_msg( _( "Your alarm clock goes off and you haven't slept a wink." ) );
-                    p->activity.set_to_null();
+                    p->activity->set_to_null();
                 }
                 add_msg( _( "You turn off your alarm-clock." ) );
                 p->get_effect( effect_alarm_clock ).set_duration( 0_turns );
@@ -1118,8 +1118,8 @@ sfx::sound_thread::sound_thread( const tripoint &source, const tripoint &target,
         vol_targ = std::max( heard_volume - 20, 0 );
     }
     ang_targ = get_heard_angle( target );
-    weapon_skill = p->weapon.melee_skill();
-    weapon_volume = p->weapon.volume() / units::legacy_volume_factor;
+    weapon_skill = p->weapon->melee_skill();
+    weapon_volume = p->weapon->volume() / units::legacy_volume_factor;
 }
 
 // Operator overload required for thread API.
@@ -1572,8 +1572,8 @@ void sfx::play_activity_sound( const std::string &id, const std::string &variant
     }
 
     avatar &player_character = get_avatar();
-    if( act != player_character.activity.id() ) {
-        act = player_character.activity.id();
+    if( act != player_character.activity->id() ) {
+        act = player_character.activity->id();
         play_ambient_variant_sound( id, variant, volume, channel::player_activities, 0 );
     }
 }

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -160,7 +160,7 @@ player_activity veh_interact::serialize_activity()
     res.values.push_back( veh->index_of_part( vpt ) ); // values[6]
     res.values.push_back( q.z );   // values[7]
     res.str_values.push_back( vp->get_id().str() );
-    res.targets.emplace_back( std::move( target ) );
+    res.targets.emplace_back( target );
 
     return res;
 }
@@ -454,7 +454,7 @@ void veh_interact::do_main_loop()
                 do_siphon();
                 // Siphoning may have started a player activity. If so, we should close the
                 // vehicle dialog and continue with the activity.
-                finish = !g->u.activity.is_null();
+                finish = !g->u.activity->is_null();
                 if( !finish ) {
                     // it's possible we just invalidated our crafting inventory
                     cache_tool_availability();
@@ -3019,19 +3019,19 @@ void act_vehicle_unload_fuel( vehicle *veh )
  */
 void veh_interact::complete_vehicle( player &p )
 {
-    if( p.activity.values.size() < 7 ) {
-        debugmsg( "Invalid activity ACT_VEHICLE values:%d", p.activity.values.size() );
+    if( p.activity->values.size() < 7 ) {
+        debugmsg( "Invalid activity ACT_VEHICLE values:%d", p.activity->values.size() );
         return;
     }
 
     map &here = get_map();
-    optional_vpart_position vp = here.veh_at( here.getlocal( tripoint( p.activity.values[0],
-                                 p.activity.values[1], p.activity.values[7] ) ) );
+    optional_vpart_position vp = here.veh_at( here.getlocal( tripoint( p.activity->values[0],
+                                 p.activity->values[1], p.activity->values[7] ) ) );
     if( !vp ) {
         // so the vehicle could have lost some of its parts from other NPCS works during this player/NPCs activity.
         // check the vehicle points that were stored at beginning of activity.
-        if( !p.activity.coord_set.empty() ) {
-            for( const auto pt : p.activity.coord_set ) {
+        if( !p.activity->coord_set.empty() ) {
+            for( const auto pt : p.activity->coord_set ) {
                 vp = here.veh_at( here.getlocal( pt ) );
                 if( vp ) {
                     break;

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -1962,7 +1962,7 @@ void veh_interact::do_siphon()
         const item &base = pt.get_base();
         const int idx = veh->find_part( base );
         //TODO!: check
-        item *liquid = item_spawn( base.contents.back() );
+        item *liquid = item::spawn( base.contents.back() );
         const int liq_charges = liquid->charges;
         if( liquid_handler::handle_liquid( *liquid, nullptr, 1, nullptr, veh, idx ) ) {
             veh->drain( idx, liq_charges - liquid->charges );
@@ -2950,7 +2950,7 @@ void act_vehicle_siphon( vehicle *veh )
     if( tank ) {
         const item &base = tank.get_base();
         const int idx = veh->find_part( base );
-        item *liquid = item_spawn( base.contents.back() );
+        item *liquid = item::spawn( base.contents.back() );
         const int liq_charges = liquid->charges;
         if( liquid_handler::handle_liquid( *liquid, nullptr, 1, nullptr, veh, idx ) ) {
             veh->drain( idx, liq_charges - liquid->charges );
@@ -3001,12 +3001,12 @@ void act_vehicle_unload_fuel( vehicle *veh )
             add_msg( m_info, _( "The vehicle has no fully charged plutonium cells." ) );
             return;
         }
-        item &plutonium = *item_spawn( fuel, calendar::turn, qty / PLUTONIUM_CHARGES );
+        item &plutonium = *item::spawn( fuel, calendar::turn, qty / PLUTONIUM_CHARGES );
         add_msg( m_info, _( "You unload %s from the vehicle." ), plutonium.display_name() );
         veh->drain( fuel, qty - ( qty % PLUTONIUM_CHARGES ) );
         g->u.i_add_or_drop( plutonium );
     } else {
-        item &solid_fuel = *item_spawn( fuel, calendar::turn, qty );
+        item &solid_fuel = *item::spawn( fuel, calendar::turn, qty );
         add_msg( m_info, _( "You unload %s from the vehicle." ), solid_fuel.display_name() );
         veh->drain( fuel, qty );
         g->u.i_add_or_drop( solid_fuel );
@@ -3077,7 +3077,7 @@ void veh_interact::complete_vehicle( player &p )
                     add_msg( m_info, _( "Could not find base part in requirements for %s." ), vpinfo.name() );
                     break;
                 } else {
-                    base = item_spawn( vpinfo.item );
+                    base = item::spawn( vpinfo.item );
                 }
             }
 

--- a/src/veh_utils.cpp
+++ b/src/veh_utils.cpp
@@ -132,7 +132,7 @@ bool repair_part( vehicle &veh, vehicle_part &pt, Character &who_c )
 
     // consume items extracting any base item (which we will need if replacing broken part)
     //TODO!: CHECK
-    item *base = item_spawn( vp.item );
+    item *base = item::spawn( vp.item );
     for( const auto &e : reqs.get_components() ) {
         for( auto &obj : who.consume_items( who.select_item_component( e, 1, map_inv ), 1,
                                             is_crafting_component ) ) {

--- a/src/veh_utils.cpp
+++ b/src/veh_utils.cpp
@@ -163,7 +163,7 @@ bool repair_part( vehicle &veh, vehicle_part &pt, Character &who_c )
         auto replacement_id = pt.info().get_id();
         get_map().spawn_items( who.pos(), pt.pieces_for_broken_part() );
         veh.remove_part( part_index );
-        const int partnum = veh.install_part( loc, replacement_id, std::move( base ) );
+        const int partnum = veh.install_part( loc, replacement_id, base );
         veh.part( partnum ).direction = dir;
         veh.part_removal_cleanup();
     } else {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -360,7 +360,7 @@ void vehicle::add_missing_frames()
         if( !found ) {
             // Install missing frame
             //TODO!: check
-            parts.emplace_back( frame_id, i.mount, *item_spawn( frame_id->item ) );
+            parts.emplace_back( frame_id, i.mount, *item::spawn( frame_id->item ) );
         }
     }
 }
@@ -1583,7 +1583,7 @@ int vehicle::install_part( point dp, const vpart_id &id, bool force )
     if( !( force || can_mount( dp, id ) ) ) {
         return -1;
     }
-    item &obj = *item_spawn( id.obj().item );
+    item &obj = *item::spawn( id.obj().item );
     int ret = install_part( dp, std::move( vehicle_part( id, dp, obj ) ) );
     return ret;
 }
@@ -5367,12 +5367,12 @@ void vehicle::slow_leak()
 
         // damaged batteries self-discharge without leaking, plutonium leaks slurry
         if( fuel != fuel_type_battery && fuel != fuel_type_plutonium_cell ) {
-            item &leak = *item_spawn( fuel, calendar::turn, qty );
+            item &leak = *item::spawn( fuel, calendar::turn, qty );
             g->m.add_item_or_charges( dest, leak );
             p.ammo_consume( qty, global_part_pos3( p ) );
         } else if( fuel == fuel_type_plutonium_cell ) {
             if( p.ammo_remaining() >= PLUTONIUM_CHARGES / 10 ) {
-                item &leak = *item_spawn( "plut_slurry_dense", calendar::turn, qty );
+                item &leak = *item::spawn( "plut_slurry_dense", calendar::turn, qty );
                 g->m.add_item_or_charges( dest, leak );
                 p.ammo_consume( qty * PLUTONIUM_CHARGES / 10, global_part_pos3( p ) );
             } else {
@@ -5423,7 +5423,7 @@ int vehicle::add_charges( int part, const item &itm )
         return 0;
     }
 
-    item &itm_copy = *item_spawn( itm );
+    item &itm_copy = *item::spawn( itm );
     itm_copy.charges = ret;
     return add_item( part, itm_copy ) ? ret : 0;
 }
@@ -5580,7 +5580,7 @@ void vehicle::place_spawn_items()
 
                 std::vector<item *> created;
                 for( const itype_id &e : spawn.item_ids ) {
-                    created.emplace_back( &item_spawn( e )->in_its_container() );
+                    created.emplace_back( &item::spawn( e )->in_its_container() );
                 }
                 for( const item_group_id &e : spawn.item_groups ) {
                     item_group::ItemList group_items = item_group::items_from( e, calendar::start_of_cataclysm );
@@ -5603,7 +5603,7 @@ void vehicle::place_spawn_items()
                                           !e->magazine_current();
 
                         if( spawn_mag ) {
-                            e->put_in( *item_spawn( e->magazine_default(), e->birthday() ) );
+                            e->put_in( *item::spawn( e->magazine_default(), e->birthday() ) );
                         }
                         if( spawn_ammo ) {
                             e->ammo_set( e->ammo_default() );
@@ -6786,7 +6786,7 @@ void vehicle::leak_fuel( vehicle_part &pt )
         int qty = pt.ammo_consume( rng( 0, std::max( pt.ammo_remaining() / 3, 1 ) ),
                                    global_part_pos3( pt ) );
         if( qty > 0 ) {
-            g->m.add_item_or_charges( random_entry( tiles ), *item_spawn( fuel, calendar::turn, qty ) );
+            g->m.add_item_or_charges( random_entry( tiles ), *item::spawn( fuel, calendar::turn, qty ) );
         }
     }
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1584,7 +1584,7 @@ int vehicle::install_part( point dp, const vpart_id &id, bool force )
         return -1;
     }
     item &obj = *item::spawn( id.obj().item );
-    int ret = install_part( dp, std::move( vehicle_part( id, dp, obj ) ) );
+    int ret = install_part( dp, vehicle_part( id, dp, obj ) );
     return ret;
 }
 
@@ -1594,7 +1594,7 @@ int vehicle::install_part( point dp, const vpart_id &id, item &obj, bool force )
         return -1;
     }
 
-    int ret = install_part( dp, std::move( vehicle_part( id, dp, obj ) ) );
+    int ret = install_part( dp, vehicle_part( id, dp, obj ) );
     return ret;
 }
 

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -135,9 +135,9 @@ void vehicle_part::remove_location_hack()
 void vehicle_part::clone_hack( const vehicle_part &source )
 {
     copy_static_from( source );
-    base = item_spawn( *source.base );
+    base = item::spawn( *source.base );
     for( item * const &it : source.items ) {
-        items.push_back( item_spawn( *it ) );
+        items.push_back( item::spawn( *it ) );
     }
 }
 
@@ -177,7 +177,7 @@ item &vehicle_part::properties_to_item() const
 {
     //TODO!: the big check
     map &here = get_map();
-    item &tmp = *item_spawn( *base );
+    item &tmp = *item::spawn( *base );
     tmp.unset_flag( "VEHICLE" );
 
     // Cables get special handling: their target coordinates need to remain
@@ -371,7 +371,7 @@ int vehicle_part::ammo_set( const itype_id &ammo, int qty )
         base->contents.clear_items();
         const auto stack = units::legacy_volume_factor / std::max( liquid->stack_size, 1 );
         const int limit = units::from_milliliter( ammo_capacity() ) / stack;
-        base->put_in( *item_spawn( ammo, calendar::turn, qty > 0 ? std::min( qty, limit ) : limit ) );
+        base->put_in( *item::spawn( ammo, calendar::turn, qty > 0 ? std::min( qty, limit ) : limit ) );
         return qty;
     }
 

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -147,7 +147,7 @@ void vehicle_part::set_location_hack( vehicle *on )
         base->set_location( new vehicle_base_item_location( on ) );
     }
     for( item *&it : items ) {
-        it->set_location( new vehicle_item_location( on ) );
+        it->set_location( new vehicle_item_spawn( on ) );
     }
 }
 

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -884,8 +884,8 @@ bool vehicle::fold_up()
     }
 
     // create a folding [non]bicycle item
-    item &bicycle = *item_spawn( can_be_folded ? "generic_folded_vehicle" : "folding_bicycle",
-                                 calendar::turn );
+    item &bicycle = *item::spawn( can_be_folded ? "generic_folded_vehicle" : "folding_bicycle",
+                                  calendar::turn );
 
     // Drop stuff in containers on ground
     for( const vpart_reference &vp : get_any_parts( "CARGO" ) ) {
@@ -1425,7 +1425,7 @@ void vehicle::operate_planter()
                     g->m.add_item( loc, *i );
                     v.erase( it );
                 } else {
-                    item *tmp = item_spawn( *i );
+                    item *tmp = item::spawn( *i );
                     tmp->charges = 1;
                     tmp->set_age( 0_turns );
                     g->m.add_item( loc, *tmp );

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -505,11 +505,11 @@ bool vehicle::interact_vehicle_locked()
                 point q = coord_translate( parts[0].mount );
                 const tripoint abs_veh_pos = global_square_location().raw();
                 //[0]
-                g->u.activity.values.push_back( abs_veh_pos.x + q.x );
+                g->u.activity->values.push_back( abs_veh_pos.x + q.x );
                 //[1]
-                g->u.activity.values.push_back( abs_veh_pos.y + q.y );
+                g->u.activity->values.push_back( abs_veh_pos.y + q.y );
                 //[2]
-                g->u.activity.values.push_back( g->u.get_skill_level( skill_mechanics ) );
+                g->u.activity->values.push_back( g->u.get_skill_level( skill_mechanics ) );
             } else {
                 if( has_security_working() && query_yn( _( "Trigger the %s's Alarm?" ), name ) ) {
                     is_alarm_on = true;
@@ -1153,8 +1153,8 @@ void vehicle::start_engines( const bool take_control, const bool autodrive )
     }
     if( !autodrive ) {
         g->u.assign_activity( ACT_START_ENGINES, start_time );
-        g->u.activity.placement = starting_engine_position - g->u.pos();
-        g->u.activity.values.push_back( take_control );
+        g->u.activity->placement = starting_engine_position - g->u.pos();
+        g->u.activity->values.push_back( take_control );
     }
 }
 
@@ -2185,8 +2185,8 @@ void vehicle::interact_with( const tripoint &pos, int interact_part )
             item_reload_option opt = character_funcs::select_ammo( you,  turret.base(), true );
             if( opt ) {
                 you.assign_activity( ACT_RELOAD, opt.moves(), opt.qty() );
-                you.activity.targets.emplace_back( turret.base() );
-                you.activity.targets.push_back( std::move( opt.ammo ) );
+                you.activity->targets.emplace_back( turret.base() );
+                you.activity->targets.push_back( opt.ammo );
             }
             return;
         }

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -630,16 +630,16 @@ void debug_menu::wishitem( player *p, const tripoint &pos )
                     if( granted->count_by_charges() ) {
                         if( amount > 0 ) {
                             granted->charges = amount;
-                            p->i_add_or_drop( *item_spawn( *granted ) );
+                            p->i_add_or_drop( *item::spawn( *granted ) );
                         }
                     } else {
                         for( int i = 0; i < amount; i++ ) {
-                            p->i_add_or_drop( *item_spawn( *granted ) );
+                            p->i_add_or_drop( *item::spawn( *granted ) );
                         }
                     }
                     p->invalidate_crafting_inventory();
                 } else if( pos.x >= 0 && pos.y >= 0 ) {
-                    g->m.add_item_or_charges( pos, *item_spawn( *granted ) );
+                    g->m.add_item_or_charges( pos, *item::spawn( *granted ) );
                     wmenu.ret = -1;
                 }
                 if( amount > 0 ) {


### PR DESCRIPTION
## how to fix `move-const-arg` with clang-tidy

1. only enable `move-const-arg` in `.clang-tidy`.
```yml
# .clang-tidy
Checks: >
  -*,
  performance-move-const-arg,
```

2. setup cmake project.
```sh
mkdir -p build
cd build
cmake .. \
    -G Ninja \
    -DCMAKE_C_COMPILER=clang \
    -DCMAKE_CXX_COMPILER=clang++ \
    -DCMAKE_CXX_FLAGS="-fuse-ld=mold -Wno-unused-command-line-argument" \
    -DUSE_HOME_DIR=OFF \
    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
    -DCURSES=OFF \
    -DTILES=ON \
    -DSOUND=ON \
    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
```

3. run [clang-tidy](https://clang.llvm.org/extra/clang-tidy/) concurrently.
```sh
run-clang-tidy -config-file .clang-tidy -fix -p build src
```

## Progress

```
[11/85] Building CXX object src/CMakeFiles/cataclysm-tiles-common.dir/ranged.cpp.o
```

almost there!